### PR TITLE
add link to slack account page

### DIFF
--- a/src/main/webapp/community.html
+++ b/src/main/webapp/community.html
@@ -44,7 +44,7 @@ layout: default
               </tr>
               <tr>
                 <td><a target="_blank" href="https://the-asf.slack.com/messages/CBP2Z98Q7/">Slack</a></td>
-                <td>Report bugs / discover known issues</td>
+                <td>Report bugs / discover known issues. Note: Please join the #unomi channel after you <a href="https://s.apache.org/slack-invite">created an account</a>. Please do not ask Unomi questions in #general.</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Added a link to the Community page where users can access slack account creation. Without this, it's impossible to access slack.

Borrowed this from Beam: https://beam.apache.org/community/contact-us/