### PR TITLE
Replace "en dash" with real "dash"

### DIFF
--- a/src/main/webapp/stories.html
+++ b/src/main/webapp/stories.html
@@ -43,7 +43,7 @@ layout: default
             <p>"Apache Unomi was chosen as our CDP due the logical and plugin architecture, because it is an Apache
                 Open Source project and specially because of its Privacy (GPDR consent management) features.
                 This lets the user own their data, but also marketers and developers improve the user journey to help
-                the users in their decision process and brand experience" – Andy Kaiser, Ninetailed founder</p>
+                the users in their decision process and brand experience" - Andy Kaiser, Ninetailed founder</p>
             <a href="https://ninetailed.io/" target="_blank">ninetailed.io</a>
         </div>
     </div>


### PR DESCRIPTION
### 🚚 Contents of change
A "en dash" characters has sneaked in the source code and does not render properly. 
I replaced it with a regular dash. 

### 🖼 Screenshot of the error
<img width="412" alt="Screenshot 2021-02-05 at 20 02 30" src="https://user-images.githubusercontent.com/592312/107077557-5374b680-67ed-11eb-832f-41b5a26bec14.png">
