### PR TITLE
Add Integrations link to (e.g.) drupal integration

### DIFF
--- a/src/main/webapp/resources.html
+++ b/src/main/webapp/resources.html
@@ -82,6 +82,8 @@ layout: default
                           </div>
                       </div>
                   </div>
+                
+
                   <hr class="featurette-divider">
 
                   <h5 class="project-heading" id="tutorials">Tutorials</h5>
@@ -89,6 +91,14 @@ layout: default
                     <li><p><a href="tutorial.html#ubuntu-tutorial">Running and Interfacing with Apache Unomi 1.3 on Ubuntu</a></p></li>
                     <li><p><a href="tutorial.html#docker-tutorial">Running Unomi 1.3 using Docker</a></p></li>
                   </ul>
+
+                  <hr class="featurette-divider">
+
+                  <h5 class="project-heading" id="integrations">Integrations</h5>
+                  <ul>
+                    <li><p><a href="https://www.drupal.org/project/unomi">Drupal</a></p></li>
+                  </ul>
+
 
                   <hr class="featurette-divider">
 


### PR DESCRIPTION
### ❓  Suggestion 
I suggest a "implementations" page where links to "module/plugin/..." implementations can be found.
For drupal (for example) we have created a module that seamlessly integrates with Apache Unomi.
This is more of a suggestion kind of PR.
Please let me know what you think of it.
We could add a similar link for mautic where there's also an integration.

### Alternative position
An alternative place could be under "download" at the install header?