### PR TITLE
Fix: make footer responsive on smaller screens

### DIFF
--- a/src/main/webapp/_layouts/default.html
+++ b/src/main/webapp/_layouts/default.html
@@ -93,7 +93,7 @@
 
     <div class="container pb-5">
         <div class="row">
-            <div class="col-3 col-md-3">
+            <div class="col-6 col-md-3 mb-4">
                 <h5>Start</h5>
                 <ul class="list-unstyled text-small">
                     <li><a href="/get-started.html" title="Get started">Get started</a></li>
@@ -102,7 +102,7 @@
                 </ul>
             </div>
 
-            <div class="col-3 col-md-3">
+            <div class="col-6 col-md-3 mb-4">
                 <h5>Documentation</h5>
                 <ul class="list-unstyled text-small">
                     <li><a href="/documentation.html" title="Main documentation">Main documentation</a></li>
@@ -112,7 +112,7 @@
                 </ul>
             </div>
 
-            <div class="col-3 col-md-3">
+            <div class="col-6 col-md-3 mb-4 ">
                 <h5>Community</h5>
                 <ul class="list-unstyled text-small">
                     <li><a href="/community/index.html" title="Mailing lists">Contact Us</a></li>
@@ -122,7 +122,7 @@
                 </ul>
             </div>
 
-            <div class="col-3 col-md-3">
+            <div class="col-6 col-md-3 mb-4">
                 <h5>About</h5>
                 <ul class="list-unstyled text-small">
                     <li><a target="_blank" href="https://www.oasis-open.org/committees/cxs/" title="OASIS Context Server Technical Committee">OASIS CXS Committee</a></li>


### PR DESCRIPTION
## Problem
- Footer columns were overlapping on smaller screen sizes.

## Changes
- updated the css to make the footer layout responsive on smaller screens.

## Jira Issue
https://issues.apache.org/jira/browse/UNOMI-931

## Screenshots
| Before | After |
|--------|-------|
|<img width="404" height="808" alt="Screenshot 2026-02-08 013222" src="https://github.com/user-attachments/assets/515c92e9-63d6-4820-a21b-90af7b2081b0" />|<img width="398" height="800" alt="Screenshot 2026-02-08 013230" src="https://github.com/user-attachments/assets/1c18546a-25ff-44c3-a2d6-1edf27f8c2ed" />|
|<img width="495" height="570" alt="Screenshot 2026-02-08 013300" src="https://github.com/user-attachments/assets/bc5c89b3-5624-454e-a9b7-7bd76f9558ce" />|<img width="492" height="702" alt="Screenshot 2026-02-08 013305" src="https://github.com/user-attachments/assets/67751bfa-69c3-4cd9-9ed6-821608d11f5f" />|
