### PR TITLE
fix: Add Foundation link, fix privacy URL, update trademark text

### DIFF
--- a/src/main/webapp/_layouts/default.html
+++ b/src/main/webapp/_layouts/default.html
@@ -318,12 +318,13 @@
             <div class="col-6 col-md-3">
                 <div class="text-uppercase fw-semibold mb-3 text-white-50 small" role="heading" aria-level="2">Apache</div>
                 <ul class="list-unstyled small">
+                    <li class="mb-2"><a href="https://www.apache.org/" target="_blank" rel="noopener" class="footer-link">Foundation</a></li>
                     <li class="mb-2"><a href="https://www.apache.org/licenses/" target="_blank" rel="noopener" class="footer-link">License</a></li>
                     <li class="mb-2"><a href="https://www.apache.org/security/" target="_blank" rel="noopener" class="footer-link">Security</a></li>
                     <li class="mb-2"><a href="https://www.apache.org/events/current-event.html" target="_blank" rel="noopener" class="footer-link">Events</a></li>
                     <li class="mb-2"><a href="https://www.apache.org/foundation/sponsorship.html" target="_blank" rel="noopener" class="footer-link">Sponsorship</a></li>
                     <li class="mb-2"><a href="https://www.apache.org/foundation/thanks.html" target="_blank" rel="noopener" class="footer-link">Thanks</a></li>
-                    <li class="mb-2"><a href="/privacy-policy.html" class="footer-link">Privacy Policy</a></li>
+                    <li class="mb-2"><a href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank" rel="noopener" class="footer-link">Privacy Policy</a></li>
                 </ul>
             </div>
         </div>
@@ -334,7 +335,7 @@
                     Copyright &copy; 2014&ndash;2026 <a href="https://www.apache.org" target="_blank" rel="noopener" class="footer-link">The Apache Software Foundation</a>. All Rights Reserved.
                 </p>
                 <p class="small text-white-50 mb-0">
-                    Apache Unomi, Unomi, Apache, the Apache feather logo are trademarks of The Apache Software Foundation.
+                    Apache Unomi, Unomi, Apache, the Apache logo are trademarks of The Apache Software Foundation.
                 </p>
             </div>
             <div class="col-md-4 text-md-end mt-3 mt-md-0">


### PR DESCRIPTION
- Adds missing Foundation link to the Apache section in footer
- Points privacy link to the canonical ASF privacy policy URL (Privacy policy says projects hace to use the top-level ASF one.)
- Updates "Apache feather logo" → "Apache logo"

Checker: https://whimsy.apache.org/site/